### PR TITLE
Cleanup installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@ no. 4, pp. 1–11, 2018.
 
 ---
 
-# 💾 Installation
+# 💾 Installation on Ubuntu/Debian
 
-Install `python3` and `pip` via:
+Install `python3`, `pip` and `venv`  via:
 
 ```bash
-sudo apt-get install python3.8 python3-pip
+sudo apt-get install python3-pip python3-venv
 ```
 
-Clone and install the repo:
+Clone and install the repo in a virtual environment:
 
 ```bash
+python3 -m venv mann-pytorch-env
+source mann-pytorch-env/bin/activate
 git clone https://github.com/ami-iit/mann-pytorch.git
 cd mann-pytorch
 pip install .


### PR DESCRIPTION
In particular: 
* Specify that the installation documentation is for Ubuntu/Debian system
* Do not install `python3.8`  explicitly, that would fail on Ubuntu 22.04, instead just rely on the fact that `python3.*` is a dependency of `python3-pip`  and `python3-venv` 
* Avoid to suggest users to install in a global location. These docs are tipically followed blindly by people with not a lot of experience, and if we suggest to install in  a globally visible location (be it `/usr/local` or `~/.local`) there is an good chance that something will either do not work in `mann-pytorch` installation, or that `mann-pytorch` will break some other workflow. A good alternative is to always suggest to install in a virtual environment. Naive users will execute everything without interfering with the rest of the setup, and expert users that for any reason do not want to install in a venv they will be able to do that if they want.