### PR TITLE
Avoid strict dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ python3 -m venv mann-pytorch-env
 source mann-pytorch-env/bin/activate
 git clone https://github.com/ami-iit/mann-pytorch.git
 cd mann-pytorch
+pip install -r requirements.txt
 pip install .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.22.2
+protobuf==3.19.4
+tensorboard==2.8.0
+torch==1.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,10 @@ package_dir =
     =src
 python_requires = >=3.6
 install_requires =
-    numpy==1.22.2
-    tensorboard==2.8.0
-    torch==1.12.1
-    protobuf==3.20.*
+    numpy>=1.22.2
+    protobuf<3.20,>=3.9.2
+    tensorboard>=2.8.0
+    torch>=1.12.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ package_dir =
 python_requires = >=3.6
 install_requires =
     numpy>=1.22.2
-    protobuf<3.20,>=3.9.2
     tensorboard>=2.8.0
     torch>=1.12.1
 


### PR DESCRIPTION
This PR addresses https://github.com/ami-iit/mann-pytorch/issues/2. 

In particular, it intended to:
- move the strict repo dependencies (i.e. with exact versions) from the `setup.cgf` to the `requirements.txt` file
- leave in the `setup.cgf` only lower/upper version bounds of the repo dependencies
